### PR TITLE
feature: add 32 byte support for rangedb

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <JetCodeStyleSettings>
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
     <codeStyleSettings language="XML">
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
@@ -111,6 +114,9 @@
           </section>
         </rules>
       </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
     <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,10 @@
       <configuration PROFILE_NAME="Debug" CONFIG_NAME="Debug" />
     </configurations>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectPlainTextFileTypeManager">
+    <file url="file://$PROJECT_DIR$/furano-common/src/test/kotlin/com/cryptoeconomicslab/furano_common/db/range/TestRangeRecordConverter.kt" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/furano-android/src/main/java/com/cryptoeconomicslab/furano_android/db/RangeDb.kt
+++ b/furano-android/src/main/java/com/cryptoeconomicslab/furano_android/db/RangeDb.kt
@@ -5,12 +5,13 @@ import com.cryptoeconomicslab.furano_common.db.KeyValueStore
 import com.cryptoeconomicslab.furano_common.db.range.RangeRecord
 import com.cryptoeconomicslab.furano_common.db.range.RangeStore
 import com.cryptoeconomicslab.furano_common.types.Bytes
-import com.cryptoeconomicslab.furano_common.types.convertFromLong
+import com.cryptoeconomicslab.furano_common.types.convertFromBigInteger
+import java.math.BigInteger
 
 
 class RangeDb(val kvs: KeyValueStore) : RangeStore {
-    override fun get(start: Long, end: Long): Array<RangeRecord> {
-        val iter = kvs.iter(convertFromLong(start))
+    override fun get(start: BigInteger, end: BigInteger): Array<RangeRecord> {
+        val iter = kvs.iter(convertFromBigInteger(start))
         val keyValue = if (iter.hasNext()) {
             iter.next()
         } else {
@@ -31,7 +32,7 @@ class RangeDb(val kvs: KeyValueStore) : RangeStore {
         return results.toTypedArray()
     }
 
-    override fun put(start: Long, end: Long, value: Bytes) {
+    override fun put(start: BigInteger, end: BigInteger, value: Bytes) {
         val inputRanges = this.delBatch(start, end)
         val outputRanges = mutableListOf<RangeRecord>()
 
@@ -70,7 +71,7 @@ class RangeDb(val kvs: KeyValueStore) : RangeStore {
         this.putBatch(outputRanges.toTypedArray())
     }
 
-    override fun del(start: Long, end: Long) {
+    override fun del(start: BigInteger, end: BigInteger) {
         this.delBatch(start, end)
     }
 
@@ -79,7 +80,7 @@ class RangeDb(val kvs: KeyValueStore) : RangeStore {
     private fun putBatch(ranges: Array<RangeRecord>) {
         val operations = ranges.map {
             BatchOperation.PutBatchOperation(
-                key = convertFromLong(it.end),
+                key = convertFromBigInteger(it.end),
                 values = it.encode()
             )
         }
@@ -87,11 +88,11 @@ class RangeDb(val kvs: KeyValueStore) : RangeStore {
         this.kvs.batch(operations = operations)
     }
 
-    private fun delBatch(start: Long, end: Long): Array<RangeRecord> {
+    private fun delBatch(start: BigInteger, end: BigInteger): Array<RangeRecord> {
         val deletedTargets = this.get(start, end)
         val operations = deletedTargets.map {
             BatchOperation.DelBatchOperation(
-                key = convertFromLong(it.end)
+                key = convertFromBigInteger(it.end)
             )
         }
 

--- a/furano-common/src/main/java/com/cryptoeconomicslab/furano_common/db/range/RangeStore.kt
+++ b/furano-common/src/main/java/com/cryptoeconomicslab/furano_common/db/range/RangeStore.kt
@@ -1,10 +1,11 @@
 package com.cryptoeconomicslab.furano_common.db.range
 
 import com.cryptoeconomicslab.furano_common.types.Bytes
+import java.math.BigInteger
 
 interface RangeStore {
-    fun get(start: Long, end: Long): Array<RangeRecord>
-    fun put(start: Long, end: Long, value: Bytes)
-    fun del(start: Long, end: Long)
+    fun get(start: BigInteger, end: BigInteger): Array<RangeRecord>
+    fun put(start: BigInteger, end: BigInteger, value: Bytes)
+    fun del(start: BigInteger, end: BigInteger)
     fun bucket(key: Bytes): RangeStore
 }

--- a/furano-common/src/main/java/com/cryptoeconomicslab/furano_common/types/Bytes.kt
+++ b/furano-common/src/main/java/com/cryptoeconomicslab/furano_common/types/Bytes.kt
@@ -1,5 +1,6 @@
 package com.cryptoeconomicslab.furano_common.types
 
+import java.math.BigInteger
 import java.nio.charset.Charset
 
 typealias Bytes = ByteArray
@@ -7,6 +8,6 @@ typealias Bytes = ByteArray
 fun Bytes.convertToString(): String = this.toString(getCharset())
 
 fun convertFromString(from: String): Bytes = from.toByteArray(getCharset())
-fun convertFromLong(from: Long): Bytes = from.toString().toByteArray(getCharset())
+fun convertFromBigInteger(from: BigInteger): Bytes = from.toString().toByteArray(getCharset())
 
 private fun getCharset(): Charset = Charset.defaultCharset()

--- a/furano-common/src/test/kotlin/com/cryptoeconomicslab/furano_common/db/range/TestRangeRecord.kt
+++ b/furano-common/src/test/kotlin/com/cryptoeconomicslab/furano_common/db/range/TestRangeRecord.kt
@@ -7,42 +7,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
-import java.nio.charset.Charset
+import java.math.BigInteger
 import kotlin.properties.Delegates
 
 class TestRangeRecord {
-
-    class TestEncode {
-
-        lateinit var target: RangeRecord
-
-        @Before
-        fun setUp() {
-            target = RangeRecord(
-                start = 100,
-                end = 200,
-                value = convertFromString("Hello World")
-            )
-        }
-
-        @Test
-        fun `given normal params, expected to be encoded`() {
-            // given
-            val encodedTargetInString = target.encode().toString(Charset.defaultCharset())
-
-            // expected
-            val expected = """
-            {
-                "start" : 100,
-                "end" : 200,
-                "value" : Hello World
-            }
-            """.trimIndent()
-
-            // assert
-            assertThat(encodedTargetInString).isEqualTo(expected)
-        }
-    }
 
     class TestIntersect {
 
@@ -50,14 +18,14 @@ class TestRangeRecord {
         var expected: Boolean by Delegates.notNull()
 
         // given
-        var start: Long by Delegates.notNull()
-        var end: Long by Delegates.notNull()
+        var start: BigInteger by Delegates.notNull()
+        var end: BigInteger by Delegates.notNull()
 
         @Before
         fun setUp() {
             target = RangeRecord(
-                start = 100,
-                end = 200,
+                start = BigInteger.valueOf(100),
+                end = BigInteger.valueOf(200),
                 value = convertFromString("Hello World")
             )
         }
@@ -65,8 +33,8 @@ class TestRangeRecord {
         @Test
         fun `given (start, end) = (0, 50), expected to return false`() {
             // given
-            start = 0
-            end = 50
+            start = BigInteger.valueOf(0)
+            end = BigInteger.valueOf(50)
 
             // expected
             expected = false
@@ -79,8 +47,8 @@ class TestRangeRecord {
         @Test
         fun `given (start, end) = (0, 100), expected to return false`() {
             // given
-            start = 0
-            end = 100
+            start = BigInteger.valueOf(0)
+            end = BigInteger.valueOf(100)
 
             // expected
             expected = false
@@ -93,8 +61,8 @@ class TestRangeRecord {
         @Test
         fun `given (start, end) = (0, 150), expected to return true`() {
             // given
-            start = 0
-            end = 150
+            start = BigInteger.valueOf(0)
+            end = BigInteger.valueOf(150)
 
             // expected
             expected = true
@@ -107,8 +75,8 @@ class TestRangeRecord {
         @Test
         fun `given (start, end) = (0, 200), expected to return true`() {
             // given
-            start = 0
-            end = 200
+            start = BigInteger.valueOf(0)
+            end = BigInteger.valueOf(200)
 
             // expected
             expected = true
@@ -121,8 +89,8 @@ class TestRangeRecord {
         @Test
         fun `given (start, end) = (0, 300), expected to return true`() {
             // given
-            start = 0
-            end = 300
+            start = BigInteger.valueOf(0)
+            end = BigInteger.valueOf(300)
 
             // expected
             expected = true
@@ -135,8 +103,8 @@ class TestRangeRecord {
         @Test
         fun `given (start, end) = (100, 200), expected to return true`() {
             // given
-            start = 100
-            end = 200
+            start = BigInteger.valueOf(100)
+            end = BigInteger.valueOf(200)
 
             // expected
             expected = true
@@ -149,8 +117,8 @@ class TestRangeRecord {
         @Test
         fun `given (start, end) = (100, 150), expected to return true`() {
             // given
-            start = 100
-            end = 150
+            start = BigInteger.valueOf(100)
+            end = BigInteger.valueOf(150)
 
             // expected
             expected = true
@@ -163,8 +131,8 @@ class TestRangeRecord {
         @Test
         fun `given (start, end) = (100, 300), expected to return true`() {
             // given
-            start = 100
-            end = 300
+            start = BigInteger.valueOf(100)
+            end = BigInteger.valueOf(300)
 
             // expected
             expected = true
@@ -177,8 +145,8 @@ class TestRangeRecord {
         @Test
         fun `given (start, end) = (150, 200), expected to return true`() {
             // given
-            start = 150
-            end = 200
+            start = BigInteger.valueOf(150)
+            end = BigInteger.valueOf(200)
 
             // expected
             expected = true
@@ -191,8 +159,8 @@ class TestRangeRecord {
         @Test
         fun `given (start, end) = (150, 300), expected to return true`() {
             // given
-            start = 150
-            end = 300
+            start = BigInteger.valueOf(150)
+            end = BigInteger.valueOf(300)
 
             // expected
             expected = true
@@ -205,8 +173,8 @@ class TestRangeRecord {
         @Test
         fun `given (start, end) = (200, 300), expected to return false`() {
             // given
-            start = 200
-            end = 300
+            start = BigInteger.valueOf(200)
+            end = BigInteger.valueOf(300)
 
             // expected
             expected = false
@@ -219,8 +187,8 @@ class TestRangeRecord {
         @Test
         fun `given (start, end) = (-100, 0), expected to throw exception when start is negative`() {
             // given
-            start = -100
-            end = 0
+            start = BigInteger.valueOf(-100)
+            end = BigInteger.valueOf(0)
 
             // assert
             try {
@@ -236,8 +204,8 @@ class TestRangeRecord {
         @Test
         fun `given (start, end) = (-200, -100), expected to throw exception when end is negative`() {
             // given
-            start = -200
-            end = -100
+            start = BigInteger.valueOf(-200)
+            end = BigInteger.valueOf(-100)
 
             // assert
             try {
@@ -253,8 +221,8 @@ class TestRangeRecord {
         @Test
         fun `given (start, end) = (200, 100), expected to throw exception when end is greater than start`() {
             // given
-            start = 200
-            end = 100
+            start = BigInteger.valueOf(200)
+            end = BigInteger.valueOf(100)
 
             // assert
             try {


### PR DESCRIPTION
Since from reasons below rangedb should support BigInteger

```
ERC20
we deposit ETH to Plasma and unit in Plasma is gwei. gwei is 10^-9 ETH. So we need at least 8 bytes range to deposit enough ETH token to Plasma.

NFT
we deposit NFT to Plasma and its id is 32 bytes. If we map NFTid and Plasma range directly, we need 32 bytes range. 
```

this PR is for supporting 32byte for end and start.